### PR TITLE
Add link to github issues

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,7 +19,10 @@ WriteMakefile(
 				url => "git://github.com/drclaw1394/perl-log-ok.git",
 				web => "http://github.com/drclaw1394/perl-log-ok",
 			}
-		}
+		},
+		bugtracker => {
+			web => 'https://github.com/drclaw1394/perl-log-ok/issues'
+         },
 	}
 
 );


### PR DESCRIPTION
I'm doing the OSDC course by @szabgab as part of this he has asked us to look for CPAN modules that could by using  github issues for problem reporting.  See [this link](https://perlmaven.com/how-to-add-link-to-version-control-system-of-a-cpan-distributionsl)  for why.  This fix is as per the link and should give you a link on your CPAN module page its  github issues.

Steve